### PR TITLE
Use batch size of 2 by default for models under variant_centered category

### DIFF
--- a/tests/test_variant_centered_scoring.py
+++ b/tests/test_variant_centered_scoring.py
@@ -17,7 +17,6 @@ def test_variant_centered_modelconfig_batchsize():
         "Basenji", **test_model_config_dict
     )
     assert test_model_config.model == "Basenji"
-    assert test_model_config.batch_size == 2
 
 
 def test_variant_centered_modelconfig():
@@ -30,7 +29,6 @@ def test_variant_centered_modelconfig():
         "DeepSEA/predict", **test_model_config_dict
     )
     assert test_model_config.model == "DeepSEA/predict"
-    assert test_model_config.batch_size == 1
     assert test_model_config.get_required_sequence_length() == 1000
     assert (
         type(test_model_config.get_transform()).__name__ == "ReorderedOneHot"


### PR DESCRIPTION
Closes: #28 
I have removed batch_size member variable from ModelConfig class
