### PR TITLE
Improved load time

### DIFF
--- a/kipoi_veff2/interval_based.py
+++ b/kipoi_veff2/interval_based.py
@@ -15,13 +15,8 @@ class ModelConfig:
     cli_to_dataloader_parameter_map: Dict[str, str]
     get_variant_info: Callable[[Dict[str, Any]], Dict[str, str]]
 
-    def __post_init__(self):
-        self.model_description = kipoi.get_model_descr(self.model)
-        self.kipoi_model_with_dataloader = kipoi.get_model(
-            self.model, source="kipoi", with_dataloader=True
-        )
-
     def get_column_labels(self) -> List:
+        self.model_description = kipoi.get_model_descr(self.model)
         targets = self.model_description.schema.targets
         column_labels = targets.column_labels
         target_shape = targets.shape[0]
@@ -43,6 +38,9 @@ class ModelConfig:
 
     # TODO: Should Any be Callable?
     def get_dataloader(self, cli_params: Dict[str, str]) -> Any:
+        self.kipoi_model_with_dataloader = kipoi.get_model(
+            self.model, source="kipoi", with_dataloader=True
+        )
         dataloader_args = {}
         if sorted(cli_params.keys()) != sorted(
             self.cli_to_dataloader_parameter_map.keys()

--- a/kipoi_veff2/variant_centered.py
+++ b/kipoi_veff2/variant_centered.py
@@ -79,7 +79,7 @@ class ModelConfig:
     ) -> List:
         targets = self.model_description.schema.targets
         column_labels = targets.column_labels
-        target_shape = targets.shape[-1]  # TODO: Verify with Ziga
+        target_shape = targets.shape[-1]
         variant_column_labels = ["#CHROM", "POS", "ID", "REF", "ALT"]
         if column_labels:
             if len(column_labels) == target_shape:

--- a/tests/test_interval_based_scoring.py
+++ b/tests/test_interval_based_scoring.py
@@ -11,13 +11,6 @@ def test_interval_based_modelconfig():
         "MMSplice/pathogenicity"
     ]
     assert test_model_config.model == "MMSplice/pathogenicity"
-    assert (
-        test_model_config.model_description.info.authors[0].name == "Jun Cheng"
-    )
-    assert (
-        type(test_model_config.kipoi_model_with_dataloader).__name__
-        == "MMSpliceModel"
-    )
 
 
 # TODO: Second item of pathogenecity output tuple is empty. Why?
@@ -78,6 +71,11 @@ def test_interval_based_scoring(
         fasta_file=fasta_file,
         gtf_file=gtf_file,
         output_file=output_file,
+    )
+    assert model_config.model_description.info.authors[0].name == "Jun Cheng"
+    assert (
+        type(model_config.kipoi_model_with_dataloader).__name__
+        == "MMSpliceModel"
     )
     assert output_file.exists()
     with open(output_file, "r") as output_file_handle:


### PR DESCRIPTION
The main issue was in ModelConfig.__post__init for kipoi_veff2.interval_based
```
self.kipoi_model_with_dataloader = kipoi.get_model(
            self.model, source="kipoi", with_dataloader=True
        )
```
This will load the tensorflow libraries when interval_based is imported in kipoi_veff2.cli. I just deferred the execution of this statement until it is necessary