### PR TITLE
Adding batch processing

### DIFF
--- a/kipoi_veff2/variant_centered.py
+++ b/kipoi_veff2/variant_centered.py
@@ -275,15 +275,19 @@ def score_variants(
             aggregated_scores = scoring_functions[0]["func"](
                 ref_predictions, alt_predictions
             )
+            if aggregated_scores.ndim == 0:
+                aggregated_scores = aggregated_scores[np.newaxis]
             if aggregated_scores.ndim == 1:
                 aggregated_scores = aggregated_scores[:, np.newaxis]
             for scoring_function in scoring_functions[1:]:
                 scores = scoring_function["func"](
                     ref_predictions, alt_predictions
                 )
-
+                if scores.ndim == 0:
+                    scores = scores[np.newaxis]
                 if scores.ndim == 1:
                     scores = scores[:, np.newaxis]
+
                 aggregated_scores = np.concatenate(
                     (
                         aggregated_scores,

--- a/kipoi_veff2/variant_centered.py
+++ b/kipoi_veff2/variant_centered.py
@@ -30,6 +30,7 @@ class ModelConfig:
     model: str
     required_sequence_length: int = None
     transform: Any = None
+    batch_size: int = 32
     default_scoring_function: Dict = field(
         default_factory=lambda: {"name": "diff", "func": scores.diff}
     )
@@ -111,14 +112,50 @@ def get_model_config(model_name: str, **kwargs) -> ModelConfig:
 VARIANT_CENTERED_MODEL_GROUP_CONFIGS = {
     "pwm_HOCOMOCO": {"required_sequence_length": 100},
     "Basenji": {
+        "batch_size": 1,
         "default_scoring_function": {
             "name": "basenji_effect",
             "func": lambda ref_pred, alt_pred: (alt_pred - ref_pred).mean(
                 axis=0
-            ),
+            )[np.newaxis, :],
         },
     },
 }
+
+
+def batcher(iterable, batch_size):
+    while True:
+        batch = list(itertools.islice(iterable, batch_size))
+        if not batch:
+            break
+        yield batch
+
+
+def batch_dataloader(
+    vcf_file: str, fasta_file: str, sequence_length: str, batch_size: int
+) -> Iterator[tuple]:
+    variant_extractor = VariantSeqExtractor(fasta_file=fasta_file)
+    for cvs in batcher(VCF(vcf_file), batch_size):
+        variants = [Variant.from_cyvcf(cv) for cv in cvs]
+        intervals = [
+            Interval(variant.chrom, variant.pos - 1, variant.pos).resize(
+                sequence_length
+            )
+            for variant in variants
+        ]
+        refs = [
+            variant_extractor.extract(
+                interval, variants=[], anchor=sequence_length
+            )
+            for interval in intervals
+        ]
+        alts = [
+            variant_extractor.extract(
+                interval, variants=[variants[index]], anchor=interval.center()
+            )
+            for index, interval in enumerate(intervals)
+        ]
+        yield (refs, alts, variants)
 
 
 def dataloader(
@@ -138,6 +175,60 @@ def dataloader(
             interval, variants=[variant], anchor=interval.center()
         )
         yield (ref, alt, variant)
+
+
+# def score_variants(
+#     model_config: ModelConfig,
+#     vcf_file: str,
+#     fasta_file: str,
+#     output_file: Union[str, Path],
+#     scoring_functions: List[Dict[str, ScoringFunction]] = [],
+# ) -> None:
+#     kipoi_model = kipoi.get_model(model_config.model)
+#     sequence_length = model_config.get_required_sequence_length()
+#     transform = model_config.get_transform()
+#     if not scoring_functions:
+#         # If no scoring function is provided through cli, fall back
+#         # on the default scoring function for the model
+#         scoring_functions = [model_config.default_scoring_function]
+#     column_labels = model_config.get_column_labels(
+#         scoring_functions=scoring_functions
+#     )
+#     with open(output_file, "w") as output_tsv:
+#         tsv_writer = csv.writer(output_tsv, delimiter="\t")
+#         tsv_writer.writerow(column_labels)
+#         for ref, alt, variant in dataloader(
+#             vcf_file, fasta_file, sequence_length
+#         ):
+#             ref_batch = transform(ref)[np.newaxis]
+#             alt_batch = transform(alt)[np.newaxis]
+#             ref_alt_batch = np.concatenate((ref_batch, alt_batch), axis=0)
+#             ref_alt_prediction = kipoi_model.predict_on_batch(ref_alt_batch)
+#             ref_prediction, alt_prediction = (
+#                 ref_alt_prediction[0],
+#                 ref_alt_prediction[1],
+#             )
+
+#             scores = [
+#                 scoring_function["func"](ref_prediction, alt_prediction)
+#                 for scoring_function in scoring_functions
+#             ]
+#             # TODO: Cleaner code
+#             scores = [
+#                 [score] if np.isscalar(score) else list(score)
+#                 for score in scores
+#             ]
+#             scores = list(itertools.chain.from_iterable(scores))
+#             tsv_writer.writerow(
+#                 [
+#                     variant.chrom,
+#                     variant.pos,
+#                     variant.id,
+#                     variant.ref,
+#                     variant.alt,
+#                 ]
+#                 + scores
+#             )
 
 
 def score_variants(
@@ -160,35 +251,59 @@ def score_variants(
     with open(output_file, "w") as output_tsv:
         tsv_writer = csv.writer(output_tsv, delimiter="\t")
         tsv_writer.writerow(column_labels)
-        for ref, alt, variant in dataloader(
-            vcf_file, fasta_file, sequence_length
-        ):
-            ref_batch = transform(ref)[np.newaxis]
-            alt_batch = transform(alt)[np.newaxis]
-            ref_alt_batch = np.concatenate((ref_batch, alt_batch), axis=0)
-            ref_alt_prediction = kipoi_model.predict_on_batch(ref_alt_batch)
-            ref_prediction, alt_prediction = (
-                ref_alt_prediction[0],
-                ref_alt_prediction[1],
-            )
 
-            scores = [
-                scoring_function["func"](ref_prediction, alt_prediction)
-                for scoring_function in scoring_functions
-            ]
-            # TODO: Cleaner code
-            scores = [
-                [score] if np.isscalar(score) else list(score)
-                for score in scores
-            ]
-            scores = list(itertools.chain.from_iterable(scores))
-            tsv_writer.writerow(
-                [
-                    variant.chrom,
-                    variant.pos,
-                    variant.id,
-                    variant.ref,
-                    variant.alt,
-                ]
-                + scores
+        for refs, alts, variants in batch_dataloader(
+            vcf_file, fasta_file, sequence_length, model_config.batch_size
+        ):
+            if model_config.batch_size == 1:
+                ref_batch = transform(refs[0])[np.newaxis]
+                alt_batch = transform(alts[0])[np.newaxis]
+                ref_alt_batch = np.concatenate((ref_batch, alt_batch), axis=0)
+                ref_alt_prediction = kipoi_model.predict_on_batch(
+                    ref_alt_batch
+                )
+                ref_predictions, alt_predictions = (
+                    ref_alt_prediction[0],
+                    ref_alt_prediction[1],
+                )
+            else:
+                refs = np.stack([transform(ref) for ref in refs], axis=0)
+                ref_predictions = kipoi_model.predict_on_batch(refs)
+                alts = np.stack([transform(alt) for alt in alts], axis=0)
+                alt_predictions = kipoi_model.predict_on_batch(alts)
+
+            aggregated_scores = scoring_functions[0]["func"](
+                ref_predictions, alt_predictions
             )
+            if aggregated_scores.ndim == 1:
+                aggregated_scores = aggregated_scores[:, np.newaxis]
+            for scoring_function in scoring_functions[1:]:
+                scores = scoring_function["func"](
+                    ref_predictions, alt_predictions
+                )
+
+                if scores.ndim == 1:
+                    scores = scores[:, np.newaxis]
+                aggregated_scores = np.concatenate(
+                    (
+                        aggregated_scores,
+                        scores,
+                    ),
+                    axis=1,
+                )
+
+            for index, variant in enumerate(variants):
+                tsv_writer.writerow(
+                    [
+                        variant.chrom,
+                        variant.pos,
+                        variant.id,
+                        variant.ref,
+                        variant.alt,
+                    ]
+                    + (
+                        [aggregated_scores[index]]
+                        if np.isscalar(aggregated_scores[index])
+                        else list(aggregated_scores[index])
+                    )
+                )

--- a/tests/test_variant_centered_scoring.py
+++ b/tests/test_variant_centered_scoring.py
@@ -17,6 +17,7 @@ def test_variant_centered_modelconfig_batchsize():
         "Basenji", **test_model_config_dict
     )
     assert test_model_config.model == "Basenji"
+    assert test_model_config.batch_size == 1
 
 
 def test_variant_centered_modelconfig():
@@ -29,6 +30,7 @@ def test_variant_centered_modelconfig():
         "DeepSEA/predict", **test_model_config_dict
     )
     assert test_model_config.model == "DeepSEA/predict"
+    assert test_model_config.batch_size == 32
     assert test_model_config.get_required_sequence_length() == 1000
     assert (
         type(test_model_config.get_transform()).__name__ == "ReorderedOneHot"


### PR DESCRIPTION
I have not tested this across all models but at least for a few (such as DeepBind) I am seeing quite a bit of speedup. I suggest to push this feature to master because at least it does not seem to have any adverse effect.
Some results with 1000 genome vcf:


Chromosome id | Number of variants | Batch size = 1 | Batch size = 32
-- | -- | -- | --
Y | 61932 | 2 | 0.8
22 | 1102765 | 21 | 14
21 | 1104782 | 33 | 14
19 | 1831069 | 34 | 27
18 | 2265476 | 66 | 44
11 | 2308950 | 52 | 28
17 | 2327621 | 67 | 45
15 | 2423081 | 70 | 47
16 | 2696144 | 75 | 50
9 | 3558080 | 106 | 44
12 | 3865553 | 74.5 | 46
10 | 3989479 | 113 | 49
8 | 4593994 | 133 | 92
7 | 4713063 | 136 | 94
6 | 5020524 | 145 | 104
5 | 5261976 | 150 | 103
3 | 5828132 | 164 | 62
1 | 6463830 | 177 | 72


