### PR TITLE
Update environment.minimal.linux.yml

### DIFF
--- a/environment.minimal.linux.yml
+++ b/environment.minimal.linux.yml
@@ -27,7 +27,7 @@ dependencies:
     - kipoi
     - kipoi-conda
     - kipoi-utils
-    - sorted-nearest==0.0.33
+    - sorted-nearest==0.0.35
     - kipoiseq
     - typing-extensions==4.1.1
     - attrs==21.4.0


### PR DESCRIPTION
This environment does not install with sorted nearest in version 0.0.33 (Cython fail). After changing the version of `sorted-nearest` to 0.0.35, the environment installs fine and seems to work just the same. Tested on MacOS 14.5 (M2)  and Linux CentOS 7. 